### PR TITLE
[Fix] Redcarpet Markdown and Render options. #113

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,14 +14,12 @@ module ApplicationHelper
   end
 
   def markdown_to_html(text)
-    markdown = Redcarpet::Markdown.new Redcarpet::Render::HTML.new(filter_html: true),
+    markdown = Redcarpet::Markdown.new Redcarpet::Render::HTML.new(filter_html: true, hard_wrap: true, xhtml: true),
                                         autolink: true,
                                         space_after_headers: true,
                                         no_intra_emphasis: true,
                                         fenced_code_blocks: true,
                                         tables: true,
-                                        hard_wrap: true,
-                                        xhtml: true,
                                         lax_html_blocks: true,
                                         strikethrough: true
 


### PR DESCRIPTION
Redcarpetのオプション指定誤りで改行入力時に改行されていなかった為、修正
#113
