### PR TITLE
Fix inactive qi-ico color.

### DIFF
--- a/app/assets/stylesheets/style.css.sass
+++ b/app/assets/stylesheets/style.css.sass
@@ -36,7 +36,7 @@
 /* sns-icon */
 
 .sns-icons
-  .fa
+  .fa, .qi-ico
     color: #999
   .qi-ico
     display: inline-block


### PR DESCRIPTION
@kanizmb Qiitaリンク未設定時のアイコンカラーが真っ黒だったのでグレーにしました。
