### PR TITLE
[WIP] ユーザー一覧を見やすく

### DIFF
--- a/app/assets/stylesheets/style.css.sass
+++ b/app/assets/stylesheets/style.css.sass
@@ -37,7 +37,7 @@
 
 .sns-icons
   .fa
-    color: #999
+    color: #ccc
   .rc-ico
     display: inline-block
     margin: 0 7px
@@ -46,5 +46,6 @@
     &:hover
       text-decoration: none
   .rc-ico-qiita
+    color: #ccc
     &.ico-active
       color: #59BB0C

--- a/app/assets/stylesheets/users.css.sass
+++ b/app/assets/stylesheets/users.css.sass
@@ -1,3 +1,42 @@
+.current_user_profile
+  .sns-icons
+    i
+      font-size: 20px
+
 .page-users.page-show
   .sns-icons
     margin-bottom: 10px
+
+
+.page-users
+  .user-profile
+    float: left
+    overflow: hidden
+    width: 260px
+    margin: 5px
+    padding: 5px
+    background-color: #fafafa
+    .user-image
+      float: left
+      width: 80px
+      img
+        background-color: #fff
+    .user-name
+      margin: 3px 0
+      font-weight: bold
+    .user-description
+      float: left
+      width: 160px
+      height: 80px
+      overflow: hidden
+      margin-left: 10px
+      .user-text
+        overflow: hidden
+        font-size: 0.85em
+      .sns-icons
+        margin-top: 5px
+        i
+          font-size: 20px
+  .pagenation-wrapper
+    margin: auto
+    text-align: center

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   def prepare_search_users
-    @q = User.order(:id).reverse_order.ransack(params[:q])
+    @q = User.order(:id).reverse_order.without_login_user(current_user).ransack(params[:q])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user, only: %i(edit update destroy)
+  before_action :current_user_profile
 
   def index
     @users = @q.result.active.page params[:page]
@@ -28,6 +29,10 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html { redirect_to :root, notice: '退会しました。' }
     end
+  end
+
+  def current_user_profile
+    @current_user_profile = set_user
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,10 @@ class User < ActiveRecord::Base
     where(introduction.not_eq(nil).and(introduction.not_eq('')))
   }
 
+  scope :without_login_user, -> (user) {
+    where.not(id: user.id)
+  }
+
   devise :trackable, :omniauthable, omniauth_providers: [:github]
 
   has_many :event_participations, dependent: :destroy

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -1,10 +1,10 @@
-.row
-  .col-md-2.user-image
+.user-profile
+  .user-image
     = link_to user_path(user.nickname) do
-      = image_tag user.image, class: 'img-circle', size: '100x100'
-    br
-    = user.name_or_nickname
-  .col-md-10
+      = image_tag user.image, size: '80x80'
+  .user-description
+    p.user-name
+      = user.name_or_nickname
     = render 'users/sns_links', user: user
-    .well
+    .user-text
       = markdown_to_html user.introduction.to_s.lines.first

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,2 +1,11 @@
-= render @users
-= paginate @users
+.col-md-2
+  .current_user_profile
+    = image_tag @current_user_profile.image, class: 'img-circle', size: '100x100'
+    p.current_user_name = @current_user_profile.name
+    = render 'users/sns_links', user: @current_user_profile
+
+.col-md-10.users-list
+  = render @users
+
+.pagenation-wrapper
+  = paginate @users


### PR DESCRIPTION
#148 を今日までになんとかしようと思っていたのですが、時間がなくて対応しきれませんでした :sweat_drops:

変更例としてざくっと書き換えてみたのでどなたか引き継いでくださいませー。
問題点はリキッドレイアウトに対応していない所です。文字数カットもできていません。
（もちろんですが、この変更は使わなくても大丈夫です。）
- [x] 複カラムにする
- [x] ログインユーザーを別に表示する
- [x] 一覧からログインユーザーを除外する
- [x] ユーザー一覧表示をコンパクトにする
- [ ] あふれる文字数カットして...で終わる
- [ ] リキッドレイアウトに対応するか固定レイアウトに変更する

![image](https://cloud.githubusercontent.com/assets/4459676/6094621/e5ad337a-af74-11e4-8c74-182e49b5ddc9.png)
