### PR TITLE
トップページのレスポンシブ対応

### DIFF
--- a/app/views/layouts/top.html.slim
+++ b/app/views/layouts/top.html.slim
@@ -1,6 +1,7 @@
 doctype html
 html
   head
+    meta name="viewport" content="width=device-width"
     title Rubyist Connect
     = favicon_link_tag 'favicon.ico'
     = favicon_link_tag 'touch-icon-iphone.png', :rel => 'apple-touch-icon', :type => 'image/png'


### PR DESCRIPTION
viewportを追記してスマホから見た時に縮小表示されないようにしました。
この辺のCSSが効くようになります。
https://github.com/rubyist-connect/rubyist-connect/blob/master/app/assets/stylesheets/top.css.sass#L179

（実機未チェックなのでうまくいっていなかったらすみません！）
