### PR TITLE
issue #134

### DIFF
--- a/app/assets/stylesheets/top.css.sass
+++ b/app/assets/stylesheets/top.css.sass
@@ -196,3 +196,10 @@
     .new-members
       ul
         width: 100%
+
+.alart-top
+  position: fixed
+  top: 5%
+  width: 80%
+  margin-left: -40%
+  left: 50%

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,6 @@
+class SessionsController < Devise::SessionsController
+  def destroy
+    super
+    flash.delete(:notice)
+  end
+end

--- a/app/views/layouts/top.html.slim
+++ b/app/views/layouts/top.html.slim
@@ -13,4 +13,5 @@ html
     = csrf_meta_tags
   body.toppage
     = yield
-    = render 'layouts/flash_messages'
+    .alart-top
+      = render 'layouts/flash_messages'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
   devise_scope :user do
-    delete '/users/sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
+    delete '/users/sign_out', to: 'sessions#destroy', as: :destroy_user_session
   end
 
   scope 'nnect' do

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -61,6 +61,22 @@ feature 'Users spec' do
     click_on 'Sign out'
     expect(page).to have_content 'Rubyist は、すぐそこに'
   end
+  
+  scenario 'ログアウト後にアラートが出ないこと' do
+    sign_in_as_new_user
+
+    click_on 'Sign out'
+
+    expect(page).to_not have_content 'ログアウトしました。'
+  end
+
+  scenario '退会後にアラートが出ること' do
+    sign_in_as_new_user
+
+    click_link '退会'
+
+    expect(page).to have_content '退会しました'
+  end
 
   scenario '退会ができること' do
     sign_in_as_new_user


### PR DESCRIPTION
https://github.com/rubyist-connect/rubyist-connect/issues/134
- ログアウトのアラートを表示しないようにしました。
- 退会、ログイン失敗時に表示されるアラートのデザインを変更しました。

![screen shot](https://cloud.githubusercontent.com/assets/904191/6095658/73425b6e-afa9-11e4-9d6a-9f5af39765d1.png)
