### PR TITLE
Issue #236

### DIFF
--- a/app/assets/stylesheets/style.css.sass
+++ b/app/assets/stylesheets/style.css.sass
@@ -7,6 +7,9 @@
 .navbar
   background-color: lighten(#9b1c16, 5%)
   padding-bottom: 0
+  .navbar-toggle
+    .icon-bar
+      background-color: #ffffff
   .navbar-brand
     color: #ffffff
     line-height: 28px

--- a/app/assets/stylesheets/users.css.sass
+++ b/app/assets/stylesheets/users.css.sass
@@ -38,5 +38,6 @@
         i
           font-size: 20px
   .pagenation-wrapper
+    clear: both
     margin: auto
     text-align: center


### PR DESCRIPTION
#236
1. 画面を狭くしたときのメニューボタンを視認できる白色に変更。
2. ページ切り替えのUIが`float`に影響されないように修正。
