### PR TITLE
support cloudfront for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,10 @@ gem 'hashie', '~> 3.4.6'
 gem 'newrelic_rpm', '~> 3.16.3'
 gem 'rack-dev-mark', '~> 0.7.5'
 
+group :production do
+  gem 'rack-cors', :require => 'rack/cors'
+end
+
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
       activerecord (>= 3.0)
     puma (3.6.0)
     rack (2.0.1)
+    rack-cors (1.0.1)
     rack-dev-mark (0.7.5)
       rack (>= 1.1)
     rack-test (0.6.3)
@@ -329,6 +330,7 @@ DEPENDENCIES
   pg (~> 0.19.0)
   poltergeist (~> 1.10.0)
   puma (~> 3.6.0)
+  rack-cors
   rack-dev-mark (~> 0.7.5)
   rails (= 5.0.0.1)
   ransack (~> 1.8.2)
@@ -350,4 +352,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.4
+   1.15.4

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,8 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  config.action_controller.asset_host = ENV['CLOUDFRONT_URL']
+  config.static_cache_control = 'public, max-age=31536000'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,8 @@
+if defined? Rack::Cors
+  Rails.application.config.middleware.insert_before 0, Rack::Cors do
+    allow do
+    origins '*'
+    resource '/assets/*', headers: :any, methods: [:get]
+    end
+  end
+end


### PR DESCRIPTION
AWS Certificate Manager + Route 53 + CloudFront によるSSL対応（https://rubyist.co/）を行ったところ、CORS (Cross-Origin Resource Sharing)対応が必要そうだったので追加してみた。うまく動かなかったら、revert します。