### PR TITLE
config.static_cache_control is deprecated 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,8 +28,10 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV['CLOUDFRONT_URL']
-  config.static_cache_control = 'public, max-age=31536000'
+  if ENV["CLOUDFRONT_URL"].present?
+    config.action_controller.asset_host = ENV['CLOUDFRONT_URL']
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=31536000' }
+  end
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
Rails 5 だったので、config.static_cache_control を削除。代わりに config.public_file_server.headers を追加