### PR TITLE
force_ssl change true

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
https://rubyist.co/ が設定された状態において、assets 配下の静的ファイルを cloudfront にリクエストする際、HTTP でリクエストすることにより、以下のエラーが発生しスタイルが適用されていない状態。
```
Mixed Content: The page at 'https://rubyist.co/' was loaded over HTTPS, but requested an insecure stylesheet 'http://***.cloudfront.net/assets/application-51116ccf82947225b6ed9885ba06f79051b4706d9ff8d819a2d24407f6f16faa.css'. This request has been blocked; the content must be served over HTTPS.
```
