### PR TITLE
Fix docker settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+!/tmp/pids/.keep
 
 /public/assets/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ LABEL maintainer 'Yuji Shimoda <yuji.shimoda@gmail.com>'
 RUN apt-get update -qq && \
     curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    apt-get install -y build-essential libpq-dev nodejs ./google-chrome-stable_current_amd64.deb
+    apt-get install -y build-essential libpq-dev nodejs ./google-chrome-stable_current_amd64.deb && \
+    gem install bundler -v 2.1.4
 RUN mkdir /app
 WORKDIR /app
 COPY Gemfile /app/Gemfile

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@ default: &default
   encoding: unicode
   host: <%= ENV.fetch('DATABASE_HOST', 'localhost') %>
   username: <%= ENV.fetch('DATABASE_USERNAME', '') %>
-  password: 
+  password: <%= ENV.fetch('DATABASE_PASSWORD', '') %>
   pool: 5
 
 development:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,15 @@ version: '3'
 services:
   db:
     image: postgres
+    environment:
+      - POSTGRES_PASSWORD=password
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
   web:
     build: .
     command: bundle exec puma -C config/puma.rb -e development -p 3000
+    environment:
+      - DATABASE_PASSWORD=password
     volumes:
       - .:/app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=password
     volumes:
-      - ./tmp/db:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
   web:
     build: .
     command: bundle exec puma -C config/puma.rb -e development -p 3000
@@ -17,3 +17,6 @@ services:
       - "3000:3000"
     depends_on:
       - db
+
+volumes:
+  db-data:


### PR DESCRIPTION
# 内容

`docker-compose up` でコンテナが起動しなかったので、起動するように設定を修正しました。

###  postgresql コンテナのセキュリティ強化によって `POSTGRES_PASSWORD` が必須になりました　(466947f)
エラーメッセージ:
```
db_1   | Error: Database is uninitialized and superuser password is not specified.
db_1   |        You must specify POSTGRES_PASSWORD to a non-empty value for the
db_1   |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
db_1   |
db_1   |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
db_1   |        connections without a password. This is *not* recommended.
db_1   |
db_1   |        See PostgreSQL documentation about "trust":
db_1   |        https://www.postgresql.org/docs/current/auth-trust.html
```

### db volume は docker volume で管理 (251ab09)

特にエラーは発生しませんでしたが、 `tmp/db` で管理するよりも、 docker volume で管理した方が Dockerの作法に則っています。

# 確認手順

1. ローカルの postgresイメージを全て削除
  ```
  docker images postgres
  # イメージ差表示されなくなるまでイメージを削除します。
  ```
2. web コンテナ起動
  ```
  docker-compose up
  ```

`rubyist-connect_web_1 exited with code 1` で終了しないことを確認する。

# DB volume の削除方法

このレポジトリのフォルダが `rubyist-connect` の場合

```
docker volume rm rubyist-connect_db-data
```