### PR TITLE
Fix bundle error of Travis CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,4 +443,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
Travis CI で bundle install でエラーが発生していました。
bundler を 2.1.4 にバージョンアップしました。

```
$ bundle install --without production --deployment
Traceback (most recent call last):
	4: from /home/travis/.rvm/gems/ruby-2.6.5/bin/ruby_executable_hooks:24:in `<main>'
	3: from /home/travis/.rvm/gems/ruby-2.6.5/bin/ruby_executable_hooks:24:in `eval'
	2: from /home/travis/.rvm/gems/ruby-2.6.5/bin/bundle:23:in `<main>'
	1: from /home/travis/.rvm/rubies/ruby-2.6.5/lib/ruby/site_ruby/2.6.0/rubygems.rb:294:in `activate_bin_path'
/home/travis/.rvm/rubies/ruby-2.6.5/lib/ruby/site_ruby/2.6.0/rubygems.rb:275:in `find_spec_for_exe': Could not find 'bundler' (1.17.3) required by your /home/travis/build/rubyist-connect/rubyist-connect/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.17.3`
```