### PR TITLE
User filtering with new event

### DIFF
--- a/app/assets/javascripts/user_filter.coffee
+++ b/app/assets/javascripts/user_filter.coffee
@@ -1,0 +1,10 @@
+$ ->
+  $('.user-filter').on 'input', ->
+    if filter = $('input.user-filter').val()
+      $.each $('.user'), ->
+        if ~$(this).data('filter-key').indexOf(filter)
+          $(this).show()
+        else
+          $(this).hide()
+    else
+      $('.user').show()

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -27,11 +27,11 @@
               => fa_icon 'check-circle', class: 'result-success result-icon-success', style: 'display:none;'
               => fa_icon 'exclamation-circle', class: 'result-error result-icon-error', style: 'display:none;'
               span.event-sync-status
-          .form-group
+          .form-group.users
               = f.label :users
-              br
+              = text_field_tag :event_users, nil, name: 'event[users]', placeholder: 'User 検索', class: 'form-control user-filter'
               = f.collection_check_boxes :user_ids, @users, :id, :name_or_nickname do |b|
-                .user.col-md-4
+                .user.col-md-4 data-filter-key="#{b.text}"
                   = b.label(class: 'checkbox-inline', title: b.text) do
                     - user = b.object
                     = b.check_box

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Event management' do
+feature 'Event management', js: true do
   scenario 'イベントが管理できること' do
     users = 10.times.map{ create :user }
 
@@ -70,6 +70,23 @@ feature 'Event management' do
 
     inactive_users.each do |user|
       expect(page).to_not have_field user.name_or_nickname
+    end
+  end
+
+  scenario 'Userがフィルタリングされること' do
+    other_users = create_list :user, 10
+    target_user = create :user, name: '山田 太郎'
+
+    sign_in_as_active_user
+    visit new_event_path
+
+    click_on 'Event'
+    click_on 'new event'
+    fill_in 'Users', with: '太'
+
+    expect(find('.users')).to have_field target_user.name_or_nickname
+    other_users.each do |user|
+      expect(find('.users')).to_not have_field user.name_or_nickname
     end
   end
 end

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -95,6 +95,7 @@ feature 'Event management' do
     expect(page).to have_content '佐藤 人志'
 
     click_on '登録する'
+    expect(page).to have_content 'Event was successfully created.'
 
     expect(page).to have_content '山田 太郎'
     expect(page).to have_content '加藤 人志'

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Event management', js: true do
+feature 'Event management' do
   scenario 'イベントが管理できること' do
     users = 10.times.map{ create :user }
 
@@ -52,7 +52,6 @@ feature 'Event management', js: true do
     # イベントを削除する
     click_on 'Event'
     click_on '削除'
-    page.driver.browser.switch_to.alert.accept
     expect(page).to have_content 'Event was successfully destroyed.'
     expect(page).to_not have_content 'KRC Hackathon'
   end
@@ -74,7 +73,7 @@ feature 'Event management', js: true do
     end
   end
 
-  scenario 'Userをフィルタリングして登録できること' do
+  scenario 'Userをフィルタリングして登録できること', js: true do
     yamada = create :user, name: '山田 太郎'
     katoh = create :user, name: '加藤 人志'
     sato = create :user, name: '佐藤 人志'

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -52,6 +52,7 @@ feature 'Event management', js: true do
     # イベントを削除する
     click_on 'Event'
     click_on '削除'
+    page.driver.browser.switch_to.alert.accept
     expect(page).to have_content 'Event was successfully destroyed.'
     expect(page).to_not have_content 'KRC Hackathon'
   end

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -74,20 +74,35 @@ feature 'Event management', js: true do
     end
   end
 
-  scenario 'Userがフィルタリングされること' do
+  scenario 'Userをフィルタリングして登録できること' do
     other_users = create_list :user, 10
-    target_user = create :user, name: '山田 太郎'
+    yamada = create :user, name: '山田 太郎'
+    katoh = create :user, name: '加藤 人志'
 
     sign_in_as_active_user
     visit new_event_path
 
     click_on 'Event'
     click_on 'new event'
-    fill_in 'Users', with: '太'
+    fill_in 'Name', with: 'KRCハッカソン'
 
-    expect(find('.users')).to have_field target_user.name_or_nickname
+    fill_in 'Users', with: '太'
+    check yamada.name_or_nickname
+    fill_in 'Users', with: '加藤'
+    check katoh.name_or_nickname
+
+    expect(page).to have_content katoh.name_or_nickname
+    ([yamada] | other_users).each do |user|
+      expect(page).to_not have_content user.name_or_nickname
+    end
+
+    click_on '登録する'
+
+    [yamada, katoh].each do |user|
+      expect(page).to have_content user.name_or_nickname
+    end
     other_users.each do |user|
-      expect(find('.users')).to_not have_field user.name_or_nickname
+      expect(page).to_not have_content user.name_or_nickname
     end
   end
 end

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -75,9 +75,9 @@ feature 'Event management', js: true do
   end
 
   scenario 'Userをフィルタリングして登録できること' do
-    other_users = create_list :user, 10
     yamada = create :user, name: '山田 太郎'
     katoh = create :user, name: '加藤 人志'
+    sato = create :user, name: '佐藤 人志'
 
     sign_in_as_active_user
     visit new_event_path
@@ -87,22 +87,18 @@ feature 'Event management', js: true do
     fill_in 'Name', with: 'KRCハッカソン'
 
     fill_in 'Users', with: '太'
-    check yamada.name_or_nickname
-    fill_in 'Users', with: '加藤'
-    check katoh.name_or_nickname
+    check '山田 太郎'
+    fill_in 'Users', with: '人'
+    check '加藤 人志'
 
-    expect(page).to have_content katoh.name_or_nickname
-    ([yamada] | other_users).each do |user|
-      expect(page).to_not have_content user.name_or_nickname
-    end
+    expect(page).to_not have_content '山田 太郎'
+    expect(page).to have_content '加藤 人志'
+    expect(page).to have_content '佐藤 人志'
 
     click_on '登録する'
 
-    [yamada, katoh].each do |user|
-      expect(page).to have_content user.name_or_nickname
-    end
-    other_users.each do |user|
-      expect(page).to_not have_content user.name_or_nickname
-    end
+    expect(page).to have_content '山田 太郎'
+    expect(page).to have_content '加藤 人志'
+    expect(page).to_not have_content '佐藤 人志'
   end
 end


### PR DESCRIPTION
## Issue

Fix #298

## 内容

* ユーザーのフィルタリング
* ~events_spec を `js:true` に変更~
  * ~アラートを閉じる必要があったので、クローズするように変更~

## 確認手順

1. Name に適当な値を入力
1. User 検索に `ratio` と入力して、 `beatae_ratione_19` をチェック
1. User 検索に `森` と入力して、 `森 大樹` をチェック
1. [登録する] をクリック
1. `beatae_ratione_19` と `森 大樹` が参加するイベントが作成される