### PR TITLE
Filtering is not case-sensitive

### DIFF
--- a/app/assets/javascripts/user_filter.coffee
+++ b/app/assets/javascripts/user_filter.coffee
@@ -2,7 +2,7 @@ $ ->
   $('.user-filter').on 'input', ->
     if filter = $('input.user-filter').val()
       $.each $('.user'), ->
-        if ~$(this).data('filter-key').indexOf(filter)
+        if ~$(this).data('filter-key').toLowerCase().indexOf(filter.toLowerCase())
           $(this).show()
         else
           $(this).hide()

--- a/app/assets/javascripts/user_filter.coffee
+++ b/app/assets/javascripts/user_filter.coffee
@@ -1,10 +1,12 @@
 $ ->
   $('.user-filter').on 'input', ->
-    if filter = $('input.user-filter').val()
+    if filter = $('input.user-filter').val().toLowerCase()
       $.each $('.user'), ->
-        if ~$(this).data('filter-key').toLowerCase().indexOf(filter.toLowerCase())
-          $(this).show()
+        targetElement = $(this)
+        userName = targetElement.data('filter-key').toLowerCase()
+        if ~userName.indexOf(filter)
+          targetElement.show()
         else
-          $(this).hide()
+          targetElement.hide()
     else
       $('.user').show()

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -74,7 +74,7 @@ feature 'Event management' do
   end
 
   scenario 'Userをフィルタリングして登録できること', js: true do
-    yamada = create :user, name: '山田 太郎'
+    yamada = create :user, name: 'Tarou Yamada'
     katoh = create :user, name: '加藤 人志'
     sato = create :user, name: '佐藤 人志'
 
@@ -85,19 +85,19 @@ feature 'Event management' do
     click_on 'new event'
     fill_in 'Name', with: 'KRCハッカソン'
 
-    fill_in 'Users', with: '太'
-    check '山田 太郎'
+    fill_in 'Users', with: 'ta'
+    check 'Tarou Yamada'
     fill_in 'Users', with: '人'
     check '加藤 人志'
 
-    expect(page).to_not have_content '山田 太郎'
+    expect(page).to_not have_content 'Tarou Yamada'
     expect(page).to have_content '加藤 人志'
     expect(page).to have_content '佐藤 人志'
 
     click_on '登録する'
     expect(page).to have_content 'Event was successfully created.'
 
-    expect(page).to have_content '山田 太郎'
+    expect(page).to have_content 'Tarou Yamada'
     expect(page).to have_content '加藤 人志'
     expect(page).to_not have_content '佐藤 人志'
   end


### PR DESCRIPTION
## Issue

Fix #361

## 内容

`indexOf` は大文字と小文字を区別していました。正規表現を用いるように変更しました。
`RexExp` の `i` オプションは大文字と小文字を区別しません。

## 確認手順

1. イベント作成ページに遷移する
1. User検索に `Magnam` と入力すると `magnam_iste_3` と `magnam_fugit_564` が表示されます。