### PR TITLE
Show only active users in user count on top page

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -4,7 +4,6 @@ class TopController < ApplicationController
     if user_signed_in?
       redirect_to users_path
     end
-
     @users = @q.result.active.reorder(Arel.sql('RANDOM()')).limit(Settings.top_page_users_count)
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -6,6 +6,5 @@ class TopController < ApplicationController
     end
 
     @users = @q.result.active.reorder(Arel.sql('RANDOM()')).limit(Settings.top_page_users_count)
-    @active_user_count = User.count{|user| user.active?}
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -4,6 +4,8 @@ class TopController < ApplicationController
     if user_signed_in?
       redirect_to users_path
     end
+
     @users = @q.result.active.reorder(Arel.sql('RANDOM()')).limit(Settings.top_page_users_count)
+    @active_user_count = User.count{|user| user.active?}
   end
 end

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -39,7 +39,7 @@ article.new-members
 
   .user-count
     .user-count-text
-      .user-count-number= User.count
+      .user-count-number= @active_user_count
       .user-count-unit rubyists
     = image_tag 'user-count-icon.png', class: 'user-count-img', size: '125x100', alt: 'User Count'
 

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -39,7 +39,7 @@ article.new-members
 
   .user-count
     .user-count-text
-      .user-count-number= @active_user_count
+      .user-count-number= User.active.count
       .user-count-unit rubyists
     = image_tag 'user-count-icon.png', class: 'user-count-img', size: '125x100', alt: 'User Count'
 

--- a/spec/features/top_spec.rb
+++ b/spec/features/top_spec.rb
@@ -36,8 +36,8 @@ feature 'Top spec' do
     visit root_path
     within '.user-count-text' do
       divs = all('div')
-      inactive_users = User.count{|user| !user.active?}
-      expect(divs.first.text.to_i).to eq User.count - inactive_users
+      inactive_user_count = User.count{|user| !user.active?}
+      expect(divs.first.text.to_i).to eq User.count - inactive_user_count
     end
   end
 

--- a/spec/features/top_spec.rb
+++ b/spec/features/top_spec.rb
@@ -29,16 +29,7 @@ feature 'Top spec' do
       expect(imgs.first['alt']).to eq active.name
     end
 
-    100.times do |n|
-      n.even? ? (create :user) : (create :user, :with_inactive_fields)
-    end
-
-    visit root_path
-    within '.user-count-text' do
-      divs = all('div')
-      inactive_user_count = User.count{|user| !user.active?}
-      expect(divs.first.text.to_i).to eq User.count - inactive_user_count
-    end
+    expect(find('.user-count-number').text).to eq '1'
   end
 
   scenario 'ランダムにユーザーが21名表示されること', retry: 3 do

--- a/spec/features/top_spec.rb
+++ b/spec/features/top_spec.rb
@@ -28,6 +28,17 @@ feature 'Top spec' do
       expect(imgs.size).to eq 1
       expect(imgs.first['alt']).to eq active.name
     end
+
+    100.times do |n|
+      n.even? ? (create :user) : (create :user, :with_inactive_fields)
+    end
+
+    visit root_path
+    within '.user-count-text' do
+      divs = all('div')
+      inactive_users = User.count{|user| !user.active?}
+      expect(divs.first.text.to_i).to eq User.count - inactive_users
+    end
   end
 
   scenario 'ランダムにユーザーが21名表示されること', retry: 3 do


### PR DESCRIPTION
Issue #373 に対応しました。

ロジックが少し増えたので変数の定義をコントローラーの方に移し、
`@active_user_count`だけをビューの方に書きました。

テストで`Capybara`と少し葛藤しましたが
なんとか書けたので、もしこれでよかったらお使いください！

よろしくお願いします