### PR TITLE
Fix count of user images in the list

### DIFF
--- a/spec/features/top_spec.rb
+++ b/spec/features/top_spec.rb
@@ -24,7 +24,7 @@ feature 'Top spec' do
     active = create :user
     visit root_path
     within '.new-members' do
-      imgs = all('img')
+      imgs = all('li img')
       expect(imgs.size).to eq 1
       expect(imgs.first['alt']).to eq active.name
     end
@@ -43,21 +43,21 @@ feature 'Top spec' do
 
     visit root_path
     within '.new-members' do
-      imgs = all('img')
+      imgs = all('li img')
       first_users << imgs.first['alt']
       expect(imgs.size).to eq 21
     end
 
     visit root_path
     within '.new-members' do
-      imgs = all('img')
+      imgs = all('li img')
       first_users << imgs.first['alt']
       expect(imgs.size).to eq 21
     end
 
     visit root_path
     within '.new-members' do
-      imgs = all('img')
+      imgs = all('li img')
       first_users << imgs.first['alt']
       expect(imgs.size).to eq 21
     end


### PR DESCRIPTION
## 内容

トップページに表示されている `.new-members img` の数が、 21 + Ruby image になっており、 `img` タグが1つ多くなっていました。
一覧表示されている `img` タグを数えるようにテストを変更しました。

これは #369 に起因しているようでした。

## 確認方法

`rspec ./spec/features/top_spec.rb` を実行して、グリーンになる。