### PR TITLE
通知メールでニックネームが入っていない場合は name を表示する

### DIFF
--- a/app/views/notification_mailer/new_user_notification.html.slim
+++ b/app/views/notification_mailer/new_user_notification.html.slim
@@ -2,7 +2,7 @@ h1 新しいRubyistが登録されました！
 
 p
   | New Rubyist:
-  b =<> @new_user.name
+  b =<> @new_user.name_or_nickname
   | さん
 
 p

--- a/spec/features/new_user_notification_spec.rb
+++ b/spec/features/new_user_notification_spec.rb
@@ -58,4 +58,30 @@ feature 'New user notification' do
       expect { click_on '更新' }.to_not change { ActionMailer::Base.deliveries.count }
     end
   end
+
+  context 'when name is nil' do
+    given!(:alice) { create :user, :with_inactive_fields, name: nil, nickname: 'alice' }
+
+    scenario 'new rubyist name using User.nickname' do
+      fill_in '自己紹介文', with: 'Hello!'
+      expect { click_on '更新' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(page).to have_content '更新しました。'
+
+      last_email = ActionMailer::Base.deliveries.last
+      expect(last_email.body).to include 'New Rubyist: <b>alice</b>'
+    end
+  end
+
+  context 'when name is not nil' do
+    given!(:alice) { create :user, :with_inactive_fields, name: 'ありす', nickname: 'alice' }
+
+    scenario 'new rubyist name using User.name' do
+      fill_in '自己紹介文', with: 'Hello!'
+      expect { click_on '更新' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(page).to have_content '更新しました。'
+
+      last_email = ActionMailer::Base.deliveries.last
+      expect(last_email.body).to include 'New Rubyist: <b>ありす</b>'
+    end
+  end
 end


### PR DESCRIPTION
## 内容

Fix #280

新しい Rubyist が追加された場合、 `name` しか表示対象になっていませんでした。
`/users/:id` では、 `name_or_nickname` を使用しているので、メールでも `name_or_nickname` を使用して、新しい Rubyist の名前が確実に表示されるようにしました。

## 確認方法

### Name が設定されている場合

1. コンソールでデータを追加
    1. `User.create(name: "name", github_id: 'name', nickname: 'name', introduction: 'Hello world', image: Faker::Avatar.image)`
1. http://rubyist-connect.test/rails/mailers/notification_mailer/new_user_notification にアクセス
1. `New Rubyist: name さん` と表示される

### Name が設定されていない場合

1. コンソールでデータを追加
    1. `User.create(github_id: 'nickname', nickname: 'nickname', introduction: 'Hello world', image: Faker::Avatar.image)`
1. http://rubyist-connect.test/rails/mailers/notification_mailer/new_user_notification にアクセス
1. `New Rubyist: nickname さん` と表示される