### PR TITLE
Show name in title for show actions

### DIFF
--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -1,5 +1,5 @@
 .event-header
-  h1.event-title= @event.name
+  h1.event-title= page_title!(@event.name)
   p.event-edit-link= link_to fa_icon('edit', text: '編集'), edit_event_path(@event)
   p #{@event.participations.count} 人
 - if @event.url.present?

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,7 +1,7 @@
 .col-sm-6.col-md-4
   = image_tag @user.image, class: 'img-circle', size: '150x150'
   br
-  = @user.name_or_nickname
+  = page_title!(@user.name_or_nickname)
   br
   = display_age(@user)
   br

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -209,8 +209,6 @@ ja:
       title: 'ユーザー編集'
     index:
       title: 'ユーザー'
-    show:
-      title: 'ユーザー表示'
   views:
     pagination:
       truncate: "..."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -202,8 +202,6 @@ ja:
       title: 'イベント'
     new:
       title: 'イベント作成'
-    show:
-      title: 'イベント表示'
   users:
     edit:
       title: 'ユーザー編集'

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -25,7 +25,8 @@ feature 'Event management' do
     expect(page).to have_content 'Event was successfully created.'
     expect(page).not_to have_css('.event_url')
 
-    # ユーザー一覧を表示する
+    # イベント一覧を表示する
+    expect(page).to have_title 'KRCハッカソン | Rubyist Connect'
     within 'h1' do
       expect(page).to have_content 'KRCハッカソン'
     end
@@ -45,6 +46,7 @@ feature 'Event management' do
     expect(page).to have_content 'Event was successfully updated.'
     expect(page).to have_css '.event_url'
     expect(page).to have_link 'http://rubyist-connect.co', href: 'http://rubyist-connect.co'
+    expect(page).to have_title 'KRC Hackathon | Rubyist Connect'
     within 'h1' do
       expect(page).to have_content 'KRC Hackathon'
     end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -24,6 +24,7 @@ feature 'Users spec' do
       click_on '更新'
     end
 
+    expect(page).to have_title 'ありす | Rubyist Connect'
     expect(page).to have_content "参加日時:2015/02/08 14:59"
     expect(page).to have_content "更新日時:2015/03/09 15:22"
 


### PR DESCRIPTION
## 内容

Fix #147

表示ページで、表示しているモデルの `name` をタイトル(`head > title`)に表示するように変更しました。
具体的には次の通り。

* `/:nickname`: ユーザー表示 | Rubyist Connect :arrow_right: 原田 優奈 | Rubyist Connect
* `/events/:id`: イベント表示 | Rubyist Connect :arrow_right: Rubyハッカソン in 大さくら村 | Rubyist Connect

## 確認方法

1. ユーザー表示
  1. https://rubyist-connect.test/nnect/mollitia_odio_994 に遷移する
  1. ブラウザのタブに `原田 優奈` が表示される
1. イベント表示
  1.  https://rubyist-connect.test/nnect/events/199 に遷移する
  1. ブラウザのタブに `Visual Basic忘年会 in 大地区` が表示される