### PR TITLE
Execute action with pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
#385 で Pull request されたものの GitHub Action が動作していませんでした。
#380 で変更するときに workflow の `on` に `pull_request` を含めるべきでした。

[この差分を取り込んだ 私のレポジトリ](https://github.com/soruma/rubyist-connect/commit/2ab94e6bcd27a32f13001287a1a4def85ba57f61)で [PR](https://github.com/soruma/rubyist-connect/pull/1) を作成して動作確認したので、これで Pull request でも GitHub Action が動作するようになります。

(これまで、自分のレポジトリでしかGitHub Action を使っていなかったので`on: [pull_request]`の必要性について理解していませんでした)
