### PR TITLE
Output user_id to log

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,8 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  # config/initializers/logging.rb で設定している
+  # config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/initializers/logging.rb
+++ b/config/initializers/logging.rb
@@ -4,7 +4,7 @@ Rails.configuration.log_tags = [
     session_key = (Rails.application.config.session_options || {})[:key]
     session_data = request.cookie_jar.encrypted[session_key] || {}
 
-    user_id = session_data.dig("warden.user.user.key", 0, 0)
-    User.find(user_id).nickname if user_id
+    # warden.user.user.key で User#id を取得
+    session_data.dig("warden.user.user.key", 0, 0)
   }
 ]

--- a/config/initializers/logging.rb
+++ b/config/initializers/logging.rb
@@ -1,0 +1,10 @@
+Rails.configuration.log_tags = [
+  :request_id,
+  -> (request) {
+    session_key = (Rails.application.config.session_options || {})[:key]
+    session_data = request.cookie_jar.encrypted[session_key] || {}
+
+    user_id = session_data.dig("warden.user.user.key", 0, 0)
+    User.find(user_id).nickname if user_id
+  }
+]


### PR DESCRIPTION
Fix #275

`development` 環境を含め全ての環境でログに `User#id` が出力されるようにしました。
適切なテストの書き方がわからなかったので、テストは書いていません。

* 未ログインの場合
  * タグが追加されない
  * `[0f7ecae6-cf8c-4c2d-ae56-cbc062bce805] Completed 200 OK in 41ms (Views: 34.3ms | ActiveRecord: 4.1ms | Allocations: 21633)`
* ログイン済みの場合
  * `User#nickname` がタグとして出力される
  * `[90c2e3f2-91e5-4324-84e6-9f6b2a240879] [125] Completed 200 OK in 1455ms (Views: 1419.8ms | ActiveRecord: 4.4ms | Allocations: 487268)`