### PR TITLE
Fix evnet participations count eager load

### DIFF
--- a/app/views/events/index.html.slim
+++ b/app/views/events/index.html.slim
@@ -8,6 +8,6 @@ table.table.table-hover
     tr
       td= link_to event.name, event
       - # TODO: i18n化
-      td #{event.participations.count} 人
+      td #{event.participations.size} 人
       td= link_to fa_icon('edit', text: '編集'), edit_event_path(event)
       td= link_to fa_icon('trash-o', text: '削除'), event_path(event), method: :delete, data: { confirm: '本当に削除しますか？' }


### PR DESCRIPTION
## 内容

ログに `SELECT COUNT(*) FROM "event_participations" WHERE "event_participations"."event_id" = $1` が大量に発行されていました。
このSQLを大量に実行しないように修正しました。

```
Started GET "/nnect/events" for 127.0.0.1 at 2020-06-28 21:58:44 +0900
Processing by EventsController#index as HTML
  User Load (0.7ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["id", 1001], ["LIMIT", 1]]
  Rendering events/index.html.slim within layouts/application
  Event Load (2.0ms)  SELECT "events".* FROM "events" ORDER BY "events"."created_at" DESC
  ↳ app/views/events/index.html.slim:7
  EventParticipation Load (27.1ms)  SELECT "event_participations".* FROM "event_participations" WHERE "event_participations"."event_id" IN ($1, (中略), $230)  [["event_id", 234], (中略), ["event_id", 1]]
  ↳ app/views/events/index.html.slim:7
   (40.8ms)  SELECT COUNT(*) FROM "event_participations" WHERE "event_participations"."event_id" = $1  [["event_id", 234]]
  ↳ app/views/events/index.html.slim:11
   (0.6ms)  SELECT COUNT(*) FROM "event_participations" WHERE "event_participations"."event_id" = $1  [["event_id", 233]]
  ↳ app/views/events/index.html.slim:11
   (0.4ms)  SELECT COUNT(*) FROM "event_participations" WHERE "event_participations"."event_id" = $1  [["event_id", 232]]
  ↳ app/views/events/index.html.slim:11
  
  (中略)

   (0.5ms)  SELECT COUNT(*) FROM "event_participations" WHERE "event_participations"."event_id" = $1  [["event_id", 2]]
  ↳ app/views/events/index.html.slim:11
   (0.6ms)  SELECT COUNT(*) FROM "event_participations" WHERE "event_participations"."event_id" = $1  [["event_id", 1]]
  ↳ app/views/events/index.html.slim:11
  Rendered events/index.html.slim within layouts/application (Duration: 1218.1ms | Allocations: 478696)
  Rendered layouts/_flash_messages.html.slim (Duration: 0.2ms | Allocations: 67)
Completed 200 OK in 1269ms (Views: 1037.2ms | ActiveRecord: 209.1ms | Allocations: 504749)
```

## 確認

1. https://rubyist-connect.test/nnect/events にアクセスする
1. ログを確認して `SELECT COUNT(*) FROM "event_participations" WHERE "event_participations"."event_id" = $1` が一度も実行されない
