### PR TITLE
Add 'user_id=' to the log tag

### DIFF
--- a/config/initializers/logging.rb
+++ b/config/initializers/logging.rb
@@ -4,7 +4,7 @@ Rails.configuration.log_tags = [
     session_key = (Rails.application.config.session_options || {})[:key]
     session_data = request.cookie_jar.encrypted[session_key] || {}
 
-    # warden.user.user.key で User#id を取得
-    session_data.dig("warden.user.user.key", 0, 0)
+    user_id = session_data.dig("warden.user.user.key", 0, 0)
+    "user_id=#{user_id}" if user_id
   }
 ]


### PR DESCRIPTION
ログのタグに 'user_id=' を付けます。

Fix #390

## Before

### 未ログインの場合

```
[e70145c3-00c6-48e6-9ae7-99a916fe9181] Completed 200 OK in 318ms (Views: 301.6ms | ActiveRecord: 5.1ms | Allocations: 77374)
```

### ログイン済みの場合

```
[2a76e329-9f5a-4db4-8d08-f7dee5999e0a] [1001] Completed 200 OK in 117ms (Views: 105.6ms | ActiveRecord: 4.0ms | Allocations: 53486)
```

## After

### 未ログインの場合

```
[ac68153a-d9be-4b84-874b-ff9a8e6fc379] Completed 200 OK in 559ms (Views: 536.8ms | ActiveRecord: 5.5ms | Allocations: 120187)
```

### ログイン済みの場合

```
[b3275067-3795-47a8-b090-6be49678fe5f] [user_id=1001] Completed 200 OK in 92ms (Views: 85.2ms | ActiveRecord: 0.6ms | Allocations: 51905)
```