### PR TITLE
ユーザの一覧で自己紹介のタグを消し、はみ出る文字を切り捨てます

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,4 +25,10 @@ module ApplicationHelper
 
     markdown.render(text).html_safe unless text.blank?
   end
+
+  # Clean up user introduction text when paginating users
+  def strip_and_truncate(text)
+    text = strip_tags(markdown_to_html(text))
+    truncate(text, length: 25)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,8 +27,8 @@ module ApplicationHelper
   end
 
   # Clean up user introduction text when paginating users
-  def strip_and_truncate(text)
+  def strip_and_truncate(text, length = 25)
     text = strip_tags(markdown_to_html(text))
-    truncate(text, length: 25)
+    truncate(text, length: length)
   end
 end

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -8,5 +8,4 @@
       = user.name_or_nickname
     = render 'users/sns_links', user: user
     .user-text
-      = markdown_to_html user.introduction.to_s.lines.first
-
+      = strip_and_truncate user.introduction.to_s.lines.first


### PR DESCRIPTION
Hello again,
またRubyist-connectにプルリクをしようと思ってコードを修正しました。

Issue #220 で取り上げられた問題なのですが、markdownからhtmlに変換された自己紹介文が
大きく表示されたりして、統一感がないということでIssueがopenされました。

helperでは`#markdown_to_html`はもうすでにあったので、その処理を通った文字列を
`#strip_tags`でhtmlを取り除き、`#truncate`で25字までにしました。

実装前：
![With tags](https://user-images.githubusercontent.com/10546292/95451034-2e3c7c80-09a2-11eb-8ff2-26c73a79dc14.png)

実装後：
![Without tags](https://user-images.githubusercontent.com/10546292/95451058-372d4e00-09a2-11eb-83ab-ff383983db52.png)

`#truncate`を導入した後：
![Truncated](https://user-images.githubusercontent.com/10546292/95451098-41e7e300-09a2-11eb-925f-e8c6e78577fd.png)

ところで、同じ機能が別のところで使えそうだと思ったので
第２引数を定義できるようにしましたが、リスト表示以外のところで
同じような処理をする予定はないんだったら、２個目のコミットを消そうかなと思います。

つまり、これの第２の引数です：
```ruby
def strip_and_truncate(text, length = 25)
    text = strip_tags(markdown_to_html(text))
    truncate(text, length: length)
end
```

またいきなりのプルリクを送ってすみません！
そして、もし英語でやりとりしたいのだったら、どうぞ英語で答えて下さい。お任せします！
よろしくお願いします。