### PR TITLE
Addressing CVE-2015-9284

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'page_title_helper'
 gem 'devise'
 gem 'omniauth'
 gem 'omniauth-github'
+gem 'omniauth-rails_csrf_protection', '~> 0.1'
 
 # Models
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,9 @@ GEM
     omniauth-oauth2 (1.7.0)
       oauth2 (~> 1.4)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     page_title_helper (4.0.0)
       rails (>= 4.2.0, < 6.1)
@@ -419,6 +422,7 @@ DEPENDENCIES
   newrelic_rpm
   omniauth
   omniauth-github
+  omniauth-rails_csrf_protection (~> 0.1)
   page_title_helper
   pg
   puma

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -35,7 +35,7 @@ article.new-members
       li
         = image_tag user.image, class: 'img-circle', size: '80x80', alt: user.name_or_nickname, data: {toggle: 'tooltip', placement: 'bottom'}, title: user.name_or_nickname
 
-  = link_to 'more...', user_github_omniauth_authorize_path, class: 'login-btn btn'
+  = link_to 'more...', user_github_omniauth_authorize_path, class: 'login-btn btn',  method: :post
 
   .user-count
     .user-count-text

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -8,7 +8,7 @@ header
       | Rubyist Connect
       span beta
     = simple_format(t('.description'), class: 'header-lead')
-    = link_to user_github_omniauth_authorize_path, class: 'login-btn btn' do
+    = link_to user_github_omniauth_authorize_path, class: 'login-btn btn', method: :post do
       = fa_icon 'github-square'
       |  Sign in with GitHub
 

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -35,6 +35,6 @@ module LoginMacros
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(oauth_params(user))
 
-    page.first('.login-btn').click
+    click_link 'Sign in with GitHub'
   end
 end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -35,6 +35,6 @@ module LoginMacros
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(oauth_params(user))
 
-    visit user_github_omniauth_authorize_path
+    page.first('.login-btn').click
   end
 end


### PR DESCRIPTION
Hello

CSRF攻撃の恐れはあんまりないかもしれませんが、
一応`/auth/:provider`のパスで`GET`を使うとそういう可能性はあるということで、
対策として[この方法](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284)に従って`POST`を使うようにしました。

```ruby
gem 'omniauth-rails_csrf_protection', '~> '0.1'
```
をインストールしてログインしようとしたら、次の`404`が表示されます：

![404](https://user-images.githubusercontent.com/10546292/99661023-93f24d00-2aa6-11eb-93c4-f06777391346.png)
ホームページのログインのリンクに`method: :post`を追加しましたので、上手く動きます。

Before:
![Before](https://user-images.githubusercontent.com/10546292/99661846-c8b2d400-2aa7-11eb-9f34-7e37d49d8e96.png)

After:
![After](https://user-images.githubusercontent.com/10546292/99661881-d2d4d280-2aa7-11eb-8425-bc2d0af901ba.png)

よろしくお願いします。