### PR TITLE
Support placement of wide image

### DIFF
--- a/app/assets/stylesheets/users.sass
+++ b/app/assets/stylesheets/users.sass
@@ -23,3 +23,8 @@
 .cancel-account-link
   float: right
   color: #9a9a9a
+
+.well-image
+  img
+    max-width: 100%
+    height: auto

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -43,5 +43,5 @@
           = link_to event_user_path(@event, next_user.nickname) do
             = "#{next_user.name_or_nickname} >>"
 .col-sm-6.col-md-8
-  .well
+  .well.well-image
     = markdown_to_html(@user.introduction)


### PR DESCRIPTION
幅広い画像が配置されている場合に、イメージが枠線(`well`)からはみ出てしまいます。
この変更で、イメージを縮小して枠線をはみ出さないようにしました。

close #367

## Test

1. http://localhost:3000/nnect/edit にアクセス
1. 自己紹介に次の内容を入力する
    ```
    プロフィール 1

    ![test](https://user-images.githubusercontent.com/11146767/80364657-4079a100-88c1-11ea-8f56-c9af78829d68.gif)

    プロフィール 2
    ```
1. 更新を押下
1. 自身のプロフィールページでイメージが `well` からはみ出さない

![image](https://user-images.githubusercontent.com/3359685/111903238-9086c680-8a84-11eb-9f02-e26d92f8b536.png)
